### PR TITLE
The status might not have containerID.

### DIFF
--- a/src/custodia/openshift/authz.py
+++ b/src/custodia/openshift/authz.py
@@ -65,7 +65,7 @@ class OpenShiftHostnameAuthz(HTTPAuthorizer):
     def find_pod(self, data, containerid):
         for pod in data['items']:
             for status in pod[u'status'][u'containerStatuses']:
-                if status[u'containerID'] == containerid:
+                if u'containerID' in status and status[u'containerID'] == containerid:
                     return pod
 
     def handle(self, request):


### PR DESCRIPTION
Addressing
```
2018-01-03 15:59:15 - server                           - Handler failed: KeyError(u'containerID',)
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/custodia/httpd/server.py", line 351, in handle_one_request
    response = self.pipeline(self.server.config, request)
  File "/usr/lib/python2.7/site-packages/custodia/httpd/server.py", line 450, in pipeline
    valid = authzers[authz].handle(request)
  File "/usr/lib/python2.7/site-packages/custodia/openshift/authz.py", line 83, in handle
    pod = self.find_pod(pods, containerid)
  File "/usr/lib/python2.7/site-packages/custodia/openshift/authz.py", line 68, in find_pod
    if status[u'containerID'] == containerid:
KeyError: u'containerID'
```

Fixes https://github.com/latchset/custodia.openshift/issues/1.